### PR TITLE
Lisätty ReferenceRepository remove_reference metodi + App.py route viitteen poistamiselle

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -88,6 +88,16 @@ def update_reference(reference_id):
 
     return redirect("/")
 
+@app.route("/remove_reference/<reference_id>", methods=["POST"])
+def remove_reference(reference_id):
+    try:
+        reference_repo.remove_reference(reference_id)
+        flash("Viite poistettu onnistuneesti!")
+        return redirect("/")
+    except Exception as error:
+        flash(str(error))
+        return redirect("/")
+
 
 # testausta varten oleva reitti
 if test_env:

--- a/src/repositories/reference_repository.py
+++ b/src/repositories/reference_repository.py
@@ -39,5 +39,20 @@ class ReferenceRepository:
         )
         self.db.session.commit()
 
+    def remove_reference(self, reference_id):
+        sql = text(
+            """
+            DELETE FROM reference_entries WHERE id = :id
+            """
+        )
+
+        self.db.session.execute(
+            sql,
+            {
+                "id": reference_id
+            }
+        )
+        self.db.session.commit()
+
 
 reference_repo = ReferenceRepository(db)

--- a/src/tests/reference_repository_test.py
+++ b/src/tests/reference_repository_test.py
@@ -37,3 +37,10 @@ class TestReferenceRepository(unittest.TestCase):
 
         self.mock_db.session.execute.assert_called_once()
         self.mock_db.session.commit.assert_called_once()
+
+
+    def test_viitteen_poisto_onnistuu(self):
+        self.repo.remove_reference(1)
+
+        self.mock_db.session.execute.assert_called_once()
+        self.mock_db.session.commit.assert_called_once()


### PR DESCRIPTION
App.py:ssä route "/remove_reference/:id" viitteen poistamiselle.

ReferenceRepositoryssa metodi poistamiselle + testi.